### PR TITLE
Contact closure genericUPS: alias NULL=none

### DIFF
--- a/docs/man/genericups.txt
+++ b/docs/man/genericups.txt
@@ -121,6 +121,8 @@ ST:: Send a BREAK on the transmit data line
 NULL:: Disable this signal.  Disabled signal will always be low except for OL
        which will always be high.
 
+none:: Alias to `NULL` which matches some other documentation.
+
 A "-" in front of a signal name (like -RNG) means that the indicated
 condition is signaled with an active low signal.  For example, [LB=-RNG]
 means the battery is low when the ring indicate line goes low, and that

--- a/drivers/genericups.c
+++ b/drivers/genericups.c
@@ -83,7 +83,7 @@ static void parse_output_signals(const char *value, int *line)
 		fatalx(EXIT_FAILURE, "Can't override output with DSR (not an output)");
 	}
 
-	if (strstr(value, "NULL")) {
+	if (strstr(value, "NULL") || strstr(value, "none")) {
 		upsdebugx(3, "%s: disable", __func__);
 		*line = 0;
 	}
@@ -161,7 +161,7 @@ static void parse_input_signals(const char *value, int *line, int *val)
 		fatalx(EXIT_FAILURE, "Can't override input with ST (not an input)");
 	}
 
-	if (strstr(value, "NULL")) {
+	if (strstr(value, "NULL") || strstr(value, "none")) {
 		*line = 0;
 		*val = 0;
 		upsdebugx(3, "%s: disable", __func__);


### PR DESCRIPTION
Going from our discussion at https://github.com/networkupstools/nut/pull/1061/#discussion_r714625490 -- does this fix make sense? If yes, please merge to bump your PR against upstream NUT :)